### PR TITLE
feat(Gemfile.lock): Add support for arm64-darwin-23 platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux


### PR DESCRIPTION
This commit adds support for the arm64-darwin-23 platform in the Gemfile.lock. This will allow the application to be run on machines with this specific architecture.