### PR TITLE
feat: add jekyll-seo-tag plugin for SEO improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "redcarpet", "~> 3.6.0"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem "jekyll-linkpreview", "~> 0.4"
+  gem "jekyll-seo-tag", "~> 2.8"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       metainspector (~> 5.9)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -141,6 +143,7 @@ DEPENDENCIES
   jekyll (~> 4.3.0)
   jekyll-feed (~> 0.6)
   jekyll-linkpreview (~> 0.4)
+  jekyll-seo-tag (~> 2.8)
   logger
   redcarpet (~> 3.6.0)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ lang: ja
 
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,31 +7,15 @@ gtag('js', new Date());
 gtag('config', 'UA-91165213-1');
 </script>
 
-<title>{% if page.title %}{{ site.title }} – {{ page.title }}{% else %}{{ site.title }} – {{ site.description }}{% endif %}</title>
 <meta charset="utf-8" />
 <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
 <meta http-equiv="content-language" content="{{ site.lang }}">
 <meta http-equiv='X-UA-Compatible' content='IE=edge'>
 <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
-{% if page.excerpt %}
-<meta name="description" content="{{ page.excerpt| strip_html }}" />
-<meta property="og:description" content="{{ page.excerpt| strip_html }}" />
-{% else %}
-<meta name="description" content="{{ site.description }}">
-<meta property="og:description" content="{{ site.description }}" />
-{% endif %}
-{% if page.image %}
-<meta property="og:image" content="{{ page.image | relative_url }}">
-{% endif %}
-<meta name="author" content="{{ site.username }}" />
-{% if page.title %}
-<meta property="og:title" content="{{ page.title }}" />
-<meta property="twitter:title" content="{{ page.title }}" />
-{% endif %}
+{% seo %}
 <!--[if lt IE 9]>
   <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" type="text/css" media="all" />
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }} - {{ site.description }}" href="{{ '/feed.xml' | relative_url }}" />
 <script type="application/javascript" src="{{ '/assets/bundle.js' | relative_url }}" data-controller="{{ page.layout }}"></script>
-


### PR DESCRIPTION
- Added `jekyll-seo-tag` gem to the Gemfile and Gemfile.lock
- Updated `_config.yml` to include `jekyll-seo-tag` in plugins
- Modified `_includes/head.html` to use `{% seo %}` tag for SEO metadata generation