### PR TITLE
Fix mobile hamburger menu search icon visibility

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,5 +1,6 @@
 ---
 import 'bootswatch/dist/lux/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
 import '../styles/global.css';
 
 export interface Props {


### PR DESCRIPTION
## Summary
- Fixes missing search icon in mobile hamburger menu
- Adds Bootstrap Icons CSS import to BaseHead.astro
- Resolves icon display issue on smartphones

## Problem
The hamburger menu on mobile devices was not showing the search icon because Bootstrap Icons CSS was not imported, even though the HTML was using `bi bi-search` classes.

## Solution
Added `import 'bootstrap-icons/font/bootstrap-icons.css';` to BaseHead.astro to ensure Bootstrap Icons are available throughout the application.

## Test plan
- [ ] Verify search icon appears in mobile hamburger menu
- [ ] Test on various mobile screen sizes
- [ ] Confirm no visual regressions on desktop

🤖 Generated with [Claude Code](https://claude.ai/code)